### PR TITLE
Change the bundleId/applicationId too

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A command-line tool that makes it trivial to set the launcher name for iOS and A
 
 # Usage
 
-1. Set your dev dependencies and your app's name
+1. Set your dev dependencies and your app's name and id (aka bundleId or applicationId, previously: package name)
 
 ```
 dev_dependencies:
@@ -12,6 +12,7 @@ dev_dependencies:
 
 flutter_app_name:
   name: "My Cool App"
+  id: "it.in4matic.flutter_app_name"
 ```
 
 2. Run flutter_app_name in your project's directory

--- a/lib/common.dart
+++ b/lib/common.dart
@@ -49,3 +49,12 @@ String fetchLauncherName(Context context) {
 
   return launcherName as String;
 }
+
+String? fetchPackageName(Context context) {
+  final yamlKeyName = context.yamlKeyName;
+
+  final Map yamlData = getYamlKeyData(context);
+  final String? packageName = yamlData["package"];
+
+  return packageName as String?;
+}

--- a/lib/common.dart
+++ b/lib/common.dart
@@ -50,11 +50,11 @@ String fetchLauncherName(Context context) {
   return launcherName as String;
 }
 
-String? fetchPackageName(Context context) {
+String? fetchId(Context context) {
   final yamlKeyName = context.yamlKeyName;
 
   final Map yamlData = getYamlKeyData(context);
-  final String? packageName = yamlData["package"];
+  final String? id = yamlData["id"];
 
-  return packageName as String?;
+  return id as String?;
 }

--- a/lib/flutter_app_name.dart
+++ b/lib/flutter_app_name.dart
@@ -17,8 +17,8 @@ void run() {
 
   ios.updateLauncherName(context);
   android.updateLauncherName(context);
-  final packageName = fetchPackageName(context);
-  if (packageName != null) {
-    changeBundleId(packageName, <Platform>[]);
+  final id = fetchId(context);
+  if (id != null) {
+    changeBundleId(id, <Platform>[]);
   }
 }

--- a/lib/flutter_app_name.dart
+++ b/lib/flutter_app_name.dart
@@ -1,7 +1,9 @@
 library flutter_app_name;
 
-import "context.dart";
+import "package:rename/rename.dart";
 
+import "context.dart";
+import "common.dart";
 import "ios.dart" as ios;
 import "android.dart" as android;
 
@@ -15,4 +17,8 @@ void run() {
 
   ios.updateLauncherName(context);
   android.updateLauncherName(context);
+  final packageName = fetchPackageName(context);
+  if (packageName != null) {
+    changeBundleId(packageName);
+  }
 }

--- a/lib/flutter_app_name.dart
+++ b/lib/flutter_app_name.dart
@@ -19,6 +19,6 @@ void run() {
   android.updateLauncherName(context);
   final packageName = fetchPackageName(context);
   if (packageName != null) {
-    await changeBundleId(packageName, <Platform>[]);
+    changeBundleId(packageName, <Platform>[]);
   }
 }

--- a/lib/flutter_app_name.dart
+++ b/lib/flutter_app_name.dart
@@ -19,6 +19,6 @@ void run() {
   android.updateLauncherName(context);
   final packageName = fetchPackageName(context);
   if (packageName != null) {
-    changeBundleId(packageName);
+    await changeBundleId(packageName, <Platform>[]);
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,13 @@
 name: flutter_app_name
 description: A package that makes it easy to set your flutter app launcher name. 
-version: 0.1.1
+version: 0.1.1+packagename
 maintainer: Frankie Primerano (@f-prime) 
 homepage: https://github.com/f-prime/flutter_app_name
 
 dependencies:
   yaml: ^3.1.0
   xml: ^5.1.2
+  rename: ^2.0.1
 
 environment:
   sdk: '>=2.12.0-0 <3.0.0'


### PR DESCRIPTION
I need to chage both the app's name and its bundleId/applicationId on Android and iOS.
There's another package doing that, it's called [rename](https://pub.dev/packages/rename). Unfortunately, though, it requires the new ID to be specified in the command line instead of pubspec.yaml, which is why I like _flutter_app_name_ better. I just combined the two packages in one; this obviously creates a dependency, which can be a problem (also because _rename_ still lacks support for Windows builds), but it might also help the packages to co-evolve.
However, I'm giving the fork back to the community, in case you can make some good use of it.
It currently accepts another field in its own pubspec section, like this:

```
flutter_app_name:
  name: "New App Name"
  id: "info.maurovanetti.new_app_id"
```