### PR TITLE
Fix different CFBundleName and CFBundleDisplayName on iOS info.plist

### DIFF
--- a/lib/common.dart
+++ b/lib/common.dart
@@ -33,7 +33,7 @@ Map getYamlKeyData(Context context) {
         "Your pubspec.yaml file must have a key ${yamlKeyName} in it.");
   }
 
-  return yamlKeyData as Map;
+  return yamlKeyData;
 }
 
 String fetchLauncherName(Context context) {
@@ -47,14 +47,12 @@ String fetchLauncherName(Context context) {
         "You must set the launcher name under the '${yamlKeyName}' section of your pubspec.yaml file.");
   }
 
-  return launcherName as String;
+  return launcherName;
 }
 
 String? fetchId(Context context) {
-  final yamlKeyName = context.yamlKeyName;
-
   final Map yamlData = getYamlKeyData(context);
   final String? id = yamlData["id"];
 
-  return id as String?;
+  return id;
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -21,7 +21,7 @@ packages:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.3.1"
   async:
     dependency: transitive
     description:
@@ -127,6 +127,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.6.3"
+  logger:
+    dependency: transitive
+    description:
+      name: logger
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.0"
   logging:
     dependency: transitive
     description:
@@ -204,6 +211,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.0"
+  rename:
+    dependency: "direct main"
+    description:
+      name: rename
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1"
   shelf:
     dependency: transitive
     description:
@@ -352,4 +366,4 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.13.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"

--- a/test/bundle_name_test.dart
+++ b/test/bundle_name_test.dart
@@ -73,6 +73,56 @@ void main() {
 </manifest>
   """;
 
+  final String iosPlistDifferentNames =
+      r"""<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Flutter App Name</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>flutter app</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UIViewControllerBasedStatusBarAppearance</key>
+	<false/>
+</dict>
+</plist>
+  """;
+
   final String iosPlist = r"""<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -193,13 +243,28 @@ void main() {
 
   test("iOS", () {
     expect(
-      ios.fetchCurrentBundleName(context, iosPlist),
-      equals('<string>Flutter App Name</string>'),
+      ios.fetchCurrentBundleNames(context, iosPlist),
+      equals({
+        "CFBundleName": '<string>Flutter App Name</string>',
+        "CFBundleDisplayName": "<string>Flutter App Name</string>"
+      }),
     );
 
     expect(
       ios.setNewBundleName(
-          context, iosPlist, '<string>Flutter App Name</string>', "Test"),
+          context,
+          iosPlist,
+          {
+            "CFBundleName": '<string>Flutter App Name</string>',
+            "CFBundleDisplayName": "<string>Flutter App Name</string>"
+          },
+          "Test"),
+      equals(iosPlistUpdated),
+    );
+
+    expect(
+      ios.setNewBundleName(context, iosPlistDifferentNames,
+          ios.fetchCurrentBundleNames(context, iosPlistDifferentNames), "Test"),
       equals(iosPlistUpdated),
     );
   });


### PR DESCRIPTION
**What**: Fix the case when users already manually change the default name of the app before.

**How:** Replaced `String bundleName` with `Map<String, String> bundleNames`, that contains CFBundleName and CFBundleDisplayName if are exists, that will replace CFBundleName and CFBundleDisplayName in Info.plist for new bundle name also if they are not equals.

Also added new test for that case and removed some unused code at `common.dart`.

P. S. It's my first public pull-request for open source, so thank you for a feedback :)